### PR TITLE
fix height of about section on safari

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -80,6 +80,7 @@ html, body {
   display: flex;
   flex-flow: row wrap;
   justify-content: space-around;
+  max-height: 230px;
 }
 
 .parent {


### PR DESCRIPTION
fixes height for safari browser


---
<sub>:balloon: i opened this PR by saying [`pls`](https://github.com/kathleenfrench/pls)</sub>
