### PR TITLE
add docker-compose local dev and slugignore file

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -1,0 +1,8 @@
+.DS_Store
+Makefile
+README.md
+todo.md
+docker-compose.yaml
+Dockerfile
+Dockerfile.local
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,59 @@
-## see: https://github.com/emk/rust-musl-builder
+# syntax=docker/dockerfile:experimental
 
-# Our first FROM statement declares the build environment.
+################################ w/ wasm-pack
+## see: https://github.com/emk/rust-musl-builder
+FROM ekidd/rust-musl-builder:latest AS local-wasm-pack
+
+RUN cargo install wasm-pack
+
+################################ wasm
+FROM local-wasm-pack as wasm
+
+WORKDIR /app
+
+COPY --chown=rust:rust web web
+COPY --chown=rust:rust static static
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/app/pkg \
+    wasm-pack build --out-dir ../pkg --release --no-typescript web/pterm
+
+################################ js assets/webpack
+FROM node:slim as assets
+
+RUN npm install -g webpack webpack-cli
+
+COPY static /static
+
+WORKDIR /web
+
+COPY --from=wasm /app/web/pkg pkg
+COPY web/package.json web/webpack.docker.js ./
+RUN npm install --legacy-peer-deps
+
+COPY web/src src
+
+RUN npm run release
+
+################################ rust-musl-builder
 FROM ekidd/rust-musl-builder:latest AS builder
 
-## add src code
 ADD --chown=rust:rust . ./
 
-RUN cargo build --release
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    cargo build --release
 
-# build our *real* docker image
+################################ actual prod image
 FROM alpine:latest
+
+ENV ENVIRONMENT Prod
 
 RUN apk --no-cache add ca-certificates
 
-COPY --from=builder \
-    /home/rust/src/target/x86_64-unknown-linux-musl/release/portfolio \
-    /usr/local/bin/
+WORKDIR /app
 
-CMD /usr/local/bin/portfolio
+COPY --from=assets /dist dist
+COPY --from=builder /home/rust/src/target/x86_64-unknown-linux-musl/release/portfolio .
+COPY config config
+
+CMD /app/portfolio

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,0 +1,17 @@
+################################ rust-musl-builder
+FROM ekidd/rust-musl-builder:latest AS builder
+
+ADD --chown=rust:rust . ./
+
+RUN cargo build --release
+
+################################ actual prod image
+FROM alpine:latest
+
+RUN apk --no-cache add ca-certificates
+
+WORKDIR /app
+
+COPY --from=builder /home/rust/src/target/x86_64-unknown-linux-musl/release/portfolio .
+
+CMD /app/portfolio

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,16 @@ local: run dist ## compiles/bundles all code, starts the rust server
 ########################################## docker
 
 .PHONY: docker
-docker: ## build the docker image for the rust server
-	@docker build -t portfolio .
+docker: ## build the docker image for the entire application
+	@DOCKER_BUILDKIT=1 docker build -t portfolio .
+
+.PHONY: up
+up: dist ## run the docker environment locally
+	@docker-compose up -d
+
+.PHONY: up
+down:
+	@docker-compose down
 
 ########################################## rust server
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,15 @@
+version: "3"
+
+services:
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile.local
+    environment: 
+      ENVIRONMENT: Prod
+      PORT: 3000
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./config:/app/config:ro
+      - ./dist:/app/dist:ro

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -91,6 +91,10 @@ html, body {
     max-height: auto !important;
   }
 
+  .flex-container img {
+    object-fit: contain !important;
+  }
+
   .visible {
     display: block !important;
   }

--- a/web/package.json
+++ b/web/package.json
@@ -8,7 +8,8 @@
     "npm": "6.14.7"
   },
   "scripts": {
-    "build": "webpack --config webpack.config.js"
+    "build": "webpack --config webpack.config.js",
+    "release": "webpack --config webpack.docker.js"
   },
   "author": "",
   "license": "ISC",
@@ -17,8 +18,7 @@
     "copy-webpack-plugin": "^5.0.3",
     "@wasm-tool/wasm-pack-plugin": "^1.3.1",
     "webpack": "5.4.0",
-    "webpack-cli": "^3.1.0",
-    "webpack-dev-server": "^3.1.5"
+    "webpack-cli": "^3.1.0"
   },
   "dependencies": {
     "path": "^0.12.7",

--- a/web/webpack.docker.js
+++ b/web/webpack.docker.js
@@ -1,0 +1,28 @@
+const path = require('path');
+const _staticDir = path.resolve(__dirname, '../static');
+const _rootDir = path.resolve(__dirname, 'src');
+const _dist = path.resolve(__dirname, "../dist");
+
+const { CleanWebpackPlugin } = require('clean-webpack-plugin');
+const CopyPlugin = require("copy-webpack-plugin");
+
+module.exports = {
+  // see: https://github.com/webpack/webpack/issues/6615
+  entry : `${_rootDir}/main.js`,
+  output : {
+    path : `${_dist}/assets/js`,
+    filename : "bundle.js",
+  },
+  mode : "production",
+  experiments: {
+    asyncWebAssembly: true,
+  },
+  plugins: [
+    new CleanWebpackPlugin(),
+    new CopyPlugin([
+      { from: _staticDir, to: `${_dist}`, ignore: ['*.css', '*.js'] },
+      { from: `${_staticDir}/css`, to: `${_dist}/assets/css` },
+      { from: `${_staticDir}/js`, to: `${_dist}/assets/js` }
+    ]),
+  ]
+};


### PR DESCRIPTION
adds local docker env for running the rust bin, mounts dist and config as bind volumes

adds a `.slugignore` file for excluding some more static assets to bring the slug size down in heroku (500mb limit) - bit difficult w/ rust deps

hence work on dockerizing deployment entirely - TK


---
<sub>:balloon: i opened this PR by saying [`pls`](https://github.com/kathleenfrench/pls)</sub>
