### PR TITLE
limit session cookie to /

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,6 @@ extern crate lazy_static;
 use actix_cors::Cors;
 use actix_session::CookieSession;
 use actix_web::{http::header, middleware, web, App, HttpServer};
-use actix_web::middleware::DefaultHeaders;
 
 use handlebars::Handlebars;
 use std::io;
@@ -68,9 +67,7 @@ async fn main() -> io::Result<()> {
             .wrap(handlers::error_handlers())
             .wrap(middleware::Logger::default())
             .app_data(handlerbars_ref.clone())
-            .service(
-                utils::file_handler("/assets", &format!("{}/", &CONFIG.static_paths.assets))
-            ).wrap(DefaultHeaders::new().header("Cache-Control", "max-age=31536000"))
+            .service(utils::file_handler("/assets", &format!("{}/", &CONFIG.static_paths.assets)))
             .configure(|s| routes::add_routes(s))
     });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,13 +37,19 @@ async fn main() -> io::Result<()> {
 
     let handlerbars_ref = web::Data::new(handlebars);
 
+    let mut secure_cookie: bool = false;
+    if &CONFIG.env.to_string() == "Prod" {
+        secure_cookie = true;
+    }
+
     let server = HttpServer::new(move || {
         App::new()
             .wrap(
                 CookieSession::signed(&[0; 32])
                     .domain(&CONFIG.server.host)
                     .name(&CONFIG.server.session_key)
-                    .secure(false),
+                    .path("/")
+                    .secure(secure_cookie),
             )
             .wrap(
                 Cors::default()

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,7 @@
+use actix_files::Files;
+
+pub fn file_handler(serve_at_path: &str, source_dir: &str) -> Files {
+  Files::new(serve_at_path, source_dir)
+    .show_files_listing()
+    .use_last_modified(true)
+}


### PR DESCRIPTION
limits session cookie to root path so as to not preclude cloudflare cache rules set on images


---
<sub>:balloon: i opened this PR by saying [`pls`](https://github.com/kathleenfrench/pls)</sub>
